### PR TITLE
Changes to machine and zone name generation

### DIFF
--- a/nixos-multi-spawn.cabal
+++ b/nixos-multi-spawn.cabal
@@ -15,7 +15,6 @@ executable nixos-multi-spawn
                        digest-pure,
                        bytestring,
                        directory,
-                       hashids,
                        filepath,
                        async,
                        aeson,

--- a/nixos-multi-spawn.nix
+++ b/nixos-multi-spawn.nix
@@ -1,5 +1,5 @@
 { mkDerivation, aeson, async, base, bytestring, concurrent-output
-, dataenc, digest-pure, directory, entropy, filepath, hashids
+, dataenc, digest-pure, directory, entropy, filepath
 , process, stdenv, systemd, tailfile-hinotify, unix
 , unordered-containers
 }:
@@ -11,7 +11,7 @@ mkDerivation {
   isExecutable = true;
   executableHaskellDepends = [
     aeson async base bytestring concurrent-output dataenc digest-pure
-    directory entropy filepath hashids process systemd
+    directory entropy filepath process systemd
     tailfile-hinotify unix unordered-containers
   ];
   license = stdenv.lib.licenses.mit;


### PR DESCRIPTION
netid is now a separate mandatory argument, used to
generate network zone name.

/dev/urandom is now always used to generate machine names.